### PR TITLE
ES7 style exponentiation is only supported by V8

### DIFF
--- a/js/entities.js
+++ b/js/entities.js
@@ -69,7 +69,7 @@ class Entity {
       this.width = this.texture.canvas.width / DIM;
       this.height = this.texture.canvas.height / DIM;
     }
-    this.radius = Math.sqrt((this.width)**2 + (this.height)**2) * 0.25;
+    this.radius = Math.sqrt(Math.pow(this.width, 2) + Math.pow(this.height, 2)) * 0.25;
     this.magnetRadius = this.radius * MAGNET_RADIUS;
     if (this instanceof Bullet) {
       this.radius /= 1.5;


### PR DESCRIPTION
Hey! Awesome, simple and educational render engine and space shooter game. I was browsing your other repositories after seeing Poxi on HN. I first got a blank screen on Firefox, because unfortunately the `**` exponentiation operator that is used in `entities.js` is only supported by Google's V8. This pull request changes it to `Math.pow`.

I was wondering under which license you want to release this. It could be used as an good educational example on how a (modern, web) render engine works, and as a template to perhaps build another game.